### PR TITLE
Finaliza o processo de checkout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+API_URL=http://localhost:5000

--- a/components/Cart.unit.spec.js
+++ b/components/Cart.unit.spec.js
@@ -112,4 +112,51 @@ describe('Cart', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('should display an input type e-mail when there are items in the cart', () => {
+    const { wrapper } = mountCart();
+    const input = wrapper.find('input[type="email"]');
+
+    expect(input.exists()).toBe(true);
+  });
+
+  it('should hide the input type e-mail when there are NO items in the cart', async () => {
+    const { wrapper } = mountCart();
+
+    wrapper.setProps({
+      products: [],
+    });
+
+    await Vue.nextTick();
+
+    const input = wrapper.find('input[type="email"]');
+
+    expect(input.exists()).toBe(false);
+  });
+
+  it('should emit checkout event and send email when checkout button is clicked', async () => {
+    const { wrapper } = mountCart();
+    const form = wrapper.find('[data-testid="checkout-form"]');
+    const input = wrapper.find('input[type="email"]');
+    const email = 'vedovelli@gmail.com';
+
+    input.setValue(email);
+
+    await form.trigger('submit');
+
+    expect(wrapper.emitted().checkout).toBeTruthy();
+    expect(wrapper.emitted().checkout).toHaveLength(1);
+    expect(wrapper.emitted().checkout[0][0]).toEqual({
+      email,
+    });
+  });
+
+  it('should NOT emit checkout event when input email is empty', async () => {
+    const { wrapper } = mountCart();
+    const button = wrapper.find('[data-testid="checkout-button"]');
+
+    await button.trigger('click');
+
+    expect(wrapper.emitted().checkout).toBeFalsy();
+  });
 });

--- a/components/Cart.vue
+++ b/components/Cart.vue
@@ -39,22 +39,41 @@
       data-testid="cart-item"
     />
     <h3 v-if="!hasProducts">Cart is empty</h3>
-    <a
-      class="flex items-center justify-center mt-4 px-3 py-2 bg-blue-600 text-white text-sm uppercase font-medium rounded hover:bg-blue-500 focus:outline-none focus:bg-blue-500"
-    >
-      <span>Checkout</span>
-      <svg
-        class="h-5 w-5 mx-2"
-        fill="none"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
+    <form data-testid="checkout-form" @submit.prevent="checkout">
+      <div v-if="hasProducts" class="mt-4">
+        <hr />
+        <label
+          class="block text-gray-700 mt-2 text-sm font-bold mb-2"
+          for="email"
+        >
+          Email
+        </label>
+        <input
+          id="email"
+          v-model="email"
+          type="email"
+          class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+        />
+      </div>
+      <button
+        data-testid="checkout-button"
+        type="submit"
+        class="flex items-center justify-center mt-4 px-3 py-2 bg-blue-600 text-white text-sm uppercase font-medium rounded hover:bg-blue-500 focus:outline-none focus:bg-blue-500"
       >
-        <path d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
-      </svg>
-    </a>
+        <span>Checkout</span>
+        <svg
+          class="h-5 w-5 mx-2"
+          fill="none"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
+        </svg>
+      </button>
+    </form>
   </div>
 </template>
 
@@ -75,6 +94,11 @@ export default {
       },
     },
   },
+  data() {
+    return {
+      email: '',
+    };
+  },
   computed: {
     hasProducts() {
       return this.products.length > 0;
@@ -83,6 +107,11 @@ export default {
   methods: {
     close() {
       this.$emit('close');
+    },
+    checkout() {
+      if (this.email) {
+        this.$emit('checkout', { email: this.email });
+      }
     },
   },
 };

--- a/components/Cart.vue
+++ b/components/Cart.vue
@@ -109,6 +109,7 @@ export default {
       this.$emit('close');
     },
     checkout() {
+      /* istanbul ignore else */
       if (this.email) {
         this.$emit('checkout', { email: this.email });
       }

--- a/components/ProductCard.vue
+++ b/components/ProductCard.vue
@@ -6,8 +6,8 @@
     >
       <button
         class="p-2 rounded-full bg-blue-600 text-white mx-5 -mb-4 hover:bg-blue-500 focus:outline-none focus:bg-blue-500"
-        @click="addToCart"
         data-testid="add-to-cart-button"
+        @click="addToCart"
       >
         <svg
           class="h-5 w-5"

--- a/layouts/default.integration.spec.js
+++ b/layouts/default.integration.spec.js
@@ -1,0 +1,104 @@
+import { mount } from '@vue/test-utils';
+import axios from 'axios';
+import DefaultLayout from '@/layouts/default';
+import Cart from '@/components/Cart';
+import { CartManager } from '@/managers/CartManager';
+import { makeServer } from '@/miragejs/server';
+
+jest.mock('axios', () => ({
+  post: jest.fn(() => ({ order: { id: 111 } })),
+  setHeader: jest.fn(),
+}));
+
+describe('Default Layout', () => {
+  let server;
+  let products;
+
+  const cartManager = new CartManager();
+
+  beforeEach(() => {
+    server = makeServer({ environment: 'test' });
+    products = server.createList('product', 2);
+  });
+
+  afterEach(() => {
+    server.shutdown();
+    jest.clearAllMocks();
+  });
+
+  it('should set email header on Axios when Cart emmits checkout event', async () => {
+    const wrapper = mount(DefaultLayout, {
+      mocks: {
+        $cart: cartManager,
+        $axios: axios,
+      },
+      stubs: {
+        Nuxt: true,
+      },
+    });
+
+    const cartComponent = wrapper.findComponent(Cart).vm;
+
+    const email = 'vedovelli@gmail.com';
+
+    await cartComponent.$emit('checkout', { email });
+
+    expect(axios.setHeader).toHaveBeenCalledTimes(1);
+    expect(axios.setHeader).toHaveBeenCalledWith('email', email);
+  });
+
+  it('should call Axios.post with the right endpoint and send products', async () => {
+    jest.spyOn(cartManager, 'getState').mockReturnValue({
+      items: products,
+    });
+
+    jest.spyOn(cartManager, 'clearProducts');
+
+    const wrapper = mount(DefaultLayout, {
+      mocks: {
+        $cart: cartManager,
+        $axios: axios,
+      },
+      stubs: {
+        Nuxt: true,
+      },
+    });
+
+    const cartComponent = wrapper.findComponent(Cart).vm;
+
+    const email = 'vedovelli@gmail.com';
+
+    await cartComponent.$emit('checkout', { email });
+
+    expect(axios.post).toHaveBeenCalledTimes(1);
+    expect(axios.post).toHaveBeenCalledWith('/api/order', { products });
+  });
+
+  it('should call cartManager.clearProducts on success', async () => {
+    jest.spyOn(cartManager, 'getState').mockReturnValue({
+      items: products,
+    });
+
+    jest.spyOn(cartManager, 'clearProducts');
+
+    const wrapper = mount(DefaultLayout, {
+      mocks: {
+        $cart: cartManager,
+        $axios: axios,
+      },
+      stubs: {
+        Nuxt: true,
+      },
+    });
+
+    const cartComponent = wrapper.findComponent(Cart).vm;
+
+    const email = 'vedovelli@gmail.com';
+
+    await cartComponent.$emit('checkout', { email });
+
+    expect(cartManager.clearProducts).toHaveBeenCalledTimes(1);
+  });
+
+  it.todo('should display error notice when Axios.post fails');
+});

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -104,6 +104,7 @@
       @close="toggleCart"
       @checkout="checkout"
     />
+    <h2 data-testid="error-message" v-if="hasError">{{ errorMessage }}</h2>
     <nuxt />
     <footer class="bg-gray-200">
       <div
@@ -123,6 +124,11 @@ import Cart from '@/components/Cart';
 
 export default {
   components: { Cart },
+  data() {
+    return {
+      errorMessage: '',
+    };
+  },
   computed: {
     isCartOpen() {
       return this.$cart.getState().open;
@@ -130,15 +136,19 @@ export default {
     products() {
       return this.$cart.getState().items;
     },
+    hasError() {
+      return this.errorMessage !== '';
+    },
   },
   methods: {
     async checkout({ email }) {
-      const products = this.$cart.getState().items;
-      this.$axios.setHeader('email', email);
-      const res = await this.$axios.post('/api/order', { products });
-
-      if (res.order.id) {
+      try {
+        const products = this.$cart.getState().items;
+        this.$axios.setHeader('email', email);
+        await this.$axios.post('/api/order', { products });
         this.$cart.clearProducts();
+      } catch (error) {
+        this.errorMessage = 'Fail to save order';
       }
     },
     toggleCart() {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -98,7 +98,12 @@
         </nav>
       </div>
     </header>
-    <cart :products="products" :is-open="isCartOpen" @close="toggleCart" />
+    <cart
+      :products="products"
+      :is-open="isCartOpen"
+      @close="toggleCart"
+      @checkout="checkout"
+    />
     <nuxt />
     <footer class="bg-gray-200">
       <div
@@ -127,6 +132,15 @@ export default {
     },
   },
   methods: {
+    async checkout({ email }) {
+      const products = this.$cart.getState().items;
+      this.$axios.setHeader('email', email);
+      const res = await this.$axios.post('/api/order', { products });
+
+      if (res.order.id) {
+        this.$cart.clearProducts();
+      }
+    },
     toggleCart() {
       if (this.$cart.getState().open) {
         this.$cart.close();

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -104,7 +104,7 @@
       @close="toggleCart"
       @checkout="checkout"
     />
-    <h2 data-testid="error-message" v-if="hasError">{{ errorMessage }}</h2>
+    <h2 v-if="hasError" data-testid="error-message">{{ errorMessage }}</h2>
     <nuxt />
     <footer class="bg-gray-200">
       <div

--- a/miragejs/seeds/index.js
+++ b/miragejs/seeds/index.js
@@ -13,7 +13,7 @@ const usersSeeder = (server) => {
 };
 
 const productsSeeder = (server) => {
-  server.createList('product', 25);
+  server.createList('product', 24);
 };
 
 export default function seeds(server) {

--- a/miragejs/server.js
+++ b/miragejs/server.js
@@ -13,6 +13,8 @@ const config = (environment) => {
     seeds,
   };
 
+  config.urlPrefix = 'http://localhost:5000';
+
   return config;
 };
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -11,11 +11,6 @@ export default {
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
   },
 
-  env: {
-    USE_API: !!process.env.USE_API,
-    API_URL: process.env.API_URL,
-  },
-
   // Global CSS (https://go.nuxtjs.dev/config-css)
   css: [],
 
@@ -36,10 +31,12 @@ export default {
     '@nuxtjs/pwa',
   ],
 
-  // Axios module configuration (https://go.nuxtjs.dev/config-axios)
-  axios: {
-    baseURL: process.env.USE_API ? process.env.API_URL : null,
+  env: {
+    USE_API: !!process.env.USE_API,
   },
+
+  // Axios module configuration (https://go.nuxtjs.dev/config-axios)
+  axios: {},
 
   // Build Configuration (https://go.nuxtjs.dev/config-build)
   build: {},

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -11,6 +11,11 @@ export default {
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
   },
 
+  env: {
+    USE_API: !!process.env.USE_API,
+    API_URL: process.env.API_URL,
+  },
+
   // Global CSS (https://go.nuxtjs.dev/config-css)
   css: [],
 
@@ -21,12 +26,7 @@ export default {
   components: false,
 
   // Modules for dev and build (recommended) (https://go.nuxtjs.dev/config-modules)
-  buildModules: [
-    // https://go.nuxtjs.dev/eslint
-    '@nuxtjs/eslint-module',
-    // https://go.nuxtjs.dev/tailwindcss
-    '@nuxtjs/tailwindcss',
-  ],
+  buildModules: ['@nuxtjs/eslint-module', '@nuxtjs/tailwindcss'],
 
   // Modules (https://go.nuxtjs.dev/config-modules)
   modules: [
@@ -37,7 +37,9 @@ export default {
   ],
 
   // Axios module configuration (https://go.nuxtjs.dev/config-axios)
-  axios: {},
+  axios: {
+    baseURL: process.env.USE_API ? process.env.API_URL : null,
+  },
 
   // Build Configuration (https://go.nuxtjs.dev/config-build)
   build: {},

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "nuxt",
+    "dev:api": "USE_API=true nuxt",
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-nuxt": "^1.0.0",
     "eslint-plugin-prettier": "^3.1.4",
     "faker": "^5.1.0",
+    "flush-promises": "^1.0.2",
     "husky": "^4.3.0",
     "jest": "^26.4.2",
     "lint-staged": "^10.3.0",

--- a/plugins/miragejs.js
+++ b/plugins/miragejs.js
@@ -1,6 +1,10 @@
 import { createServer, Response } from 'miragejs';
-
-if (process.env.NODE_ENV === 'development') {
+// eslint-disable-next-line
+console.log({
+  USE_API: process.env.USE_API,
+  API_URL: process.env.API_URL,
+});
+if (process.env.NODE_ENV === 'development' && !process.env.USE_API) {
   require('@/miragejs/server').makeServer();
 }
 

--- a/plugins/miragejs.js
+++ b/plugins/miragejs.js
@@ -1,9 +1,5 @@
 import { createServer, Response } from 'miragejs';
-// eslint-disable-next-line
-console.log({
-  USE_API: process.env.USE_API,
-  API_URL: process.env.API_URL,
-});
+
 if (process.env.NODE_ENV === 'development' && !process.env.USE_API) {
   require('@/miragejs/server').makeServer();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5321,6 +5321,11 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
+flush-promises@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/flush-promises/-/flush-promises-1.0.2.tgz#4948fd58f15281fed79cbafc86293d5bb09b2ced"
+  integrity sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==
+
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"


### PR DESCRIPTION
Como a API requer que um e-mail seja adicionado ao header das chamadas, permitindo assim que a compra seja feita sem a necessidade da criação de um usuário, é necessário que o Cart tenha um campo para que o usuário informe seu e-mail.

Ao preencher o campo e clicar no botão CHECKOUT, um evento é emitido e o pai do Cart faz a chamada POST para a API, adicionando o email num header e enviando os produtos.

Este PR implementa este caso de uso, com todos os testes necessários.

![image](https://user-images.githubusercontent.com/151001/108956521-1d01bd00-7670-11eb-8020-d5a35dd4c565.png)

